### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,10 +13,10 @@ ESC	KEYWORD1
 #######################################
 attach	KEYWORD2
 detach	KEYWORD2
-write KEYWORD2
+write	KEYWORD2
 attached	KEYWORD2
 writeMicroseconds	KEYWORD2
-arm  KEYWORD2
+arm	KEYWORD2
 disarm	KEYWORD2
 isArmed	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords